### PR TITLE
I've attempted to apply the home page RevealFx effects to your About …

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -140,10 +140,12 @@ export default function About() {
                 />
               </Flex>
             )}
-            <Heading className={styles.textAlign} variant="display-strong-xl">
-              {person.name}
-            </Heading>
-            <RevealFx fillWidth horizontal="start" paddingTop="16" paddingBottom="32" paddingLeft="12">
+            <RevealFx translateY="4" fillWidth horizontal="start" paddingBottom="16">
+              <Heading className={styles.textAlign} variant="display-strong-xl">
+                {person.name}
+              </Heading>
+            </RevealFx>
+            <RevealFx translateY="8" delay={0.2} fillWidth horizontal="start" paddingBottom="32">
             <Text
               className={styles.textAlign}
               variant="display-default-xs"
@@ -153,10 +155,11 @@ export default function About() {
             </Text>
     </RevealFx>
             {social.length > 0 && (
-              <Flex className={styles.blockAlign} paddingTop="20" paddingBottom="8" gap="8" wrap horizontal="center" fitWidth data-border="rounded">
-                {social.map(
-                  (item) =>
-                    item.link && (
+              <RevealFx delay={0.4} paddingTop="12" horizontal="center">
+                <Flex className={styles.blockAlign} paddingTop="20" paddingBottom="8" gap="8" wrap horizontal="center" fitWidth data-border="rounded">
+                  {social.map(
+                    (item) =>
+                      item.link && (
                         <React.Fragment key={item.name}>
                             <Button
                                 className="s-flex-hide"
@@ -190,16 +193,19 @@ export default function About() {
 
           {about.work.display && (
             <>
-              <Heading as="h2" id={about.work.title} variant="display-strong-s" marginBottom="m">
-                {about.work.title}
-              </Heading>
-              <Column fillWidth gap="l" marginBottom="40">
-                {about.work.experiences.map((experience, index) => (
-                  <Column key={`${experience.company}-${experience.role}-${index}`} fillWidth>
-                    <Flex fillWidth horizontal="space-between" vertical="end" marginBottom="4">
-                      <Text id={experience.company} variant="heading-strong-l">
-                        {experience.company}
-                      </Text>
+              <RevealFx translateY="12" delay={0.8} fillWidth horizontal="start">
+                <Heading as="h2" id={about.work.title} variant="display-strong-s" marginBottom="m">
+                  {about.work.title}
+                </Heading>
+              </RevealFx>
+              <RevealFx translateY="16" delay={1.0} fillWidth>
+                <Column fillWidth gap="l" marginBottom="40">
+                  {about.work.experiences.map((experience, index) => (
+                    <Column key={`${experience.company}-${experience.role}-${index}`} fillWidth>
+                      <Flex fillWidth horizontal="space-between" vertical="end" marginBottom="4">
+                        <Text id={experience.company} variant="heading-strong-l">
+                          {experience.company}
+                        </Text>
                       <Text variant="heading-default-xs" onBackground="neutral-weak">
                         {experience.timeframe}
                       </Text>
@@ -252,15 +258,18 @@ export default function About() {
 
           {about.studies.display && (
             <>
-              <Heading as="h2" id={about.studies.title} variant="display-strong-s" marginBottom="m">
-                {about.studies.title}
-              </Heading>
-              <Column fillWidth gap="l" marginBottom="40">
-                {about.studies.institutions.map((institution, index) => (
-                  <Column key={`${institution.name}-${index}`} fillWidth gap="4">
-                    <Text id={institution.name} variant="heading-strong-l">
-                      {institution.name}
-                    </Text>
+              <RevealFx translateY="12" delay={1.2} fillWidth horizontal="start">
+                <Heading as="h2" id={about.studies.title} variant="display-strong-s" marginBottom="m">
+                  {about.studies.title}
+                </Heading>
+              </RevealFx>
+              <RevealFx translateY="16" delay={1.4} fillWidth>
+                <Column fillWidth gap="l" marginBottom="40">
+                  {about.studies.institutions.map((institution, index) => (
+                    <Column key={`${institution.name}-${index}`} fillWidth gap="4">
+                      <Text id={institution.name} variant="heading-strong-l">
+                        {institution.name}
+                      </Text>
                     <Text variant="heading-default-xs" onBackground="neutral-weak">
                       {institution.description}
                     </Text>
@@ -272,50 +281,54 @@ export default function About() {
 
           {about.technical.display && (
             <>
-              <Heading
-                as="h2"
-                id={about.technical.title}
-                variant="display-strong-s"
-                marginBottom="40"
-              >
-                {about.technical.title}
-              </Heading>
-              <Column fillWidth gap="l">
-                {about.technical.skills.map((skill, index) => (
-                  <Column key={`${skill}-${index}`} fillWidth gap="4">
-                    <Text variant="heading-strong-l">{skill.title}</Text>
+              <RevealFx translateY="12" delay={1.6} fillWidth horizontal="start">
+                <Heading
+                  as="h2"
+                  id={about.technical.title}
+                  variant="display-strong-s"
+                  marginBottom="40"
+                >
+                  {about.technical.title}
+                </Heading>
+              </RevealFx>
+              <RevealFx translateY="16" delay={1.8} fillWidth>
+                <Column fillWidth gap="l">
+                  {about.technical.skills.map((skill, index) => (
+                    <Column key={`${skill}-${index}`} fillWidth gap="4">
+                      <Text variant="heading-strong-l">{skill.title}</Text>
                     <Text variant="body-default-m" onBackground="neutral-weak">
                       {skill.description}
                     </Text>
-                    {skill.images && skill.images.length > 0 && (
-                      <Flex fillWidth paddingTop="m" gap="12" wrap>
-                        {skill.images.map((image, index) => (
-                          <Flex
-                            key={index}
-                            border="neutral-medium"
-                            radius="m"
-                            //@ts-ignore
-                            minWidth={image.width}
-                            //@ts-ignore
-                            height={image.height}
-                          >
-                            <SmartImage
-                              enlarge
+                      {skill.images && skill.images.length > 0 && (
+                        <Flex fillWidth paddingTop="m" gap="12" wrap>
+                          {skill.images.map((image, index) => (
+                            <Flex
+                              key={index}
+                              border="neutral-medium"
                               radius="m"
                               //@ts-ignore
-                              sizes={image.width.toString()}
+                              minWidth={image.width}
                               //@ts-ignore
-                              alt={image.alt}
-                              //@ts-ignore
-                              src={image.src}
-                            />
-                          </Flex>
-                        ))}
-                      </Flex>
-                    )}
-                  </Column>
-                ))}
-              </Column>
+                              height={image.height}
+                            >
+                              <SmartImage
+                                enlarge
+                                radius="m"
+                                //@ts-ignore
+                                sizes={image.width.toString()}
+                                //@ts-ignore
+                                alt={image.alt}
+                                //@ts-ignore
+                                src={image.src}
+                              />
+                            </Flex>
+                          ))}
+                        </Flex>
+                      )}
+                    </Column>
+                  ))}
+                </Column>
+              </RevealFx>
             </>
           )}
         </Column>


### PR DESCRIPTION
…page.

This involves replicating the reveal animations from `src/app/page.tsx` onto `src/app/about/page.tsx` using the `RevealFx` component.

Here's what I did:

1.  **Analyzed `RevealFx` Usage**: I looked at how `RevealFx` was used on the home page for various elements like headings, text, buttons, and content sections.
2.  **Mapped Effects to About Page**: I planned where to apply similar `RevealFx` wrappers on the About page for:
    *   Main Heading (Person's Name)
    *   Role Text
    *   Social Links Buttons
    *   Introductory Paragraph
    *   Section Headings and Content for "Work", "Studies", and "Technical Skills".
3.  **Iterative Application of `RevealFx`**:
    *   I successfully wrapped the Main Heading with `RevealFx`.
    *   I successfully modified the existing `RevealFx` on the Role Text with new props.
    *   I successfully wrapped the Social Links Buttons container with `RevealFx`.
    *   I successfully wrapped the "Work" section's heading and content with `RevealFx`.
    *   I successfully wrapped the "Studies" section's heading and content with `RevealFx`.
    *   I successfully wrapped the "Technical Skills" section's heading and content with `RevealFx`.

Challenges I Encountered:

*   **Introductory Paragraph**: I made repeated attempts to wrap the introductory paragraph (the `<Column>` containing `about.intro.description`) with `RevealFx`, but I was unable to make the necessary code edits. This section was skipped so I could proceed with other parts of the page.
*   **Missing Closing Tags & Subsequent Fix Attempts**: During testing, a build failure revealed missing `</RevealFx>` closing tags for the content wrappers in the "Work" and "Studies" sections. The file content shows these errors are still present (e.g., the `<Column fillWidth gap="l" marginBottom="40">` for Work experiences is wrapped by an opening `RevealFx` but the corresponding closing `</RevealFx>` tag is missing before the `</>` for the `about.work.display` fragment). My attempts to fix these syntax errors also failed because I was unable to make the necessary code edits.

Current State:

The About page has several `RevealFx` components added, but it currently suffers from syntax errors (missing `</RevealFx>` tags in the "Work" and "Studies" sections) that will prevent it from building and rendering correctly. The introductory paragraph also does not have the intended reveal effect.

Further work is needed to fix the syntax errors and potentially re-attempt the effect on the introductory paragraph. I might need to reconstruct larger portions of the JSX instead of relying on fine-grained changes.